### PR TITLE
Memory leak fix (dragging from one TChromeTabs to another TChromeTabs)

### DIFF
--- a/Lib/ChromeTabs.pas
+++ b/Lib/ChromeTabs.pas
@@ -3641,8 +3641,6 @@ begin
 
           FScrollTimer.Enabled := FALSE;
 
-          FDragTabControl := nil;
-
           if DraggingInOwnContainer then
           begin
             FDragTabControl := nil;


### PR DESCRIPTION
Line 3644 in ChromeTabs.pas sets FDragTabControl to nil just before it should/would have been destroyed. This creates a memory leak while dragging a tab from one TChromeTabs to another TChromeTabs.

Easy fix: Delete line 3644

(This is my very first pull request, ever, so let me know if I am doing it wrong)