### PR TITLE
Version number and mouse behavior fix.

### DIFF
--- a/Lib/ChromeTabs.pas
+++ b/Lib/ChromeTabs.pas
@@ -2056,7 +2056,8 @@ begin
               Tabs[FMouseDownHitTest.TabIndex].Active := TRUE;
             end;
           end
-          else if Button = {$IFDEF EXPLICIT_DRAW_STATE}TMouseButton.{$ENDIF}mbMiddle then
+          else if (Button = {$IFDEF EXPLICIT_DRAW_STATE}TMouseButton.{$ENDIF}mbMiddle)
+                   and (FMouseDownHitTest.HitTestArea = htTab) then
           begin
             HitTestResult := HitTest(Point(X, Y));
             AllowClose := True;
@@ -2644,7 +2645,7 @@ begin
       EndDrag(X, Y, FDragCancelled);
     end;
 
-    if (HitTestResult.HitTestArea = htAddButton) and
+    if (FMouseButton = mbLeft) and (HitTestResult.HitTestArea = htAddButton) and
        (FMouseDownHitTest.HitTestArea = htAddButton) then
     begin
       DoOnButtonAddClick;

--- a/Packages/Delphi DX12/ChromeTabs_D.dproj
+++ b/Packages/Delphi DX12/ChromeTabs_D.dproj
@@ -87,7 +87,7 @@
     </PropertyGroup>
     <PropertyGroup Condition="'$(Cfg_2_Win32)'!=''">
         <VerInfo_Locale>1033</VerInfo_Locale>
-        <DllVersion>350</DllVersion>
+        <DllVersion>290</DllVersion>
     </PropertyGroup>
     <ItemGroup>
         <DelphiCompile Include="$(MainSource)">

--- a/Packages/Delphi DX12/ChromeTabs_R.dproj
+++ b/Packages/Delphi DX12/ChromeTabs_R.dproj
@@ -77,7 +77,7 @@
         <DCC_UsePackage>vcl;$(DCC_UsePackage)</DCC_UsePackage>
         <VerInfo_Locale>1033</VerInfo_Locale>
         <VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
-        <DllVersion>350</DllVersion>
+        <DllVersion>290</DllVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win64)'!=''">
         <DCC_BplOutput>$(BDSCOMMONDIR)\Bpl\Win64</DCC_BplOutput>


### PR DESCRIPTION
Clicking the new page button with the middle mouse button triggers an exception. 

Right-clicking the new page button opens a new tab after the popupmenu appears, which is strange.
